### PR TITLE
Splunk http event collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ By default
     * logger level can be set by `CONSOLE_LOG_LEVEL` env variable; defaults to `silly`
   * the `splunk` logger is added if `NODE_ENV === production`
     * logger level can be set by `SPLUNK_LOG_LEVEL` env variable; defaults to `warn`
+  * the `splunkHEC` logger is added if `NODE_ENV === production && SPLUNK_HEC_TOKEN`
+    * logger level can be set by `SPLUNK_LOG_LEVEL` env variable; defaults to `warn`
 
 ### API
 
@@ -49,6 +51,10 @@ By default
 #### addSplunk(splunkUrl, level = 'info', opts = {})
 
 #### removeSplunk()
+
+#### addSplunkHEC(level = 'info', opts = {})
+
+#### removeSplunkHEC()
 
 #### clearLoggers()
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prepush": "make verify -j3"
   },
   "dependencies": {
-    "@financial-times/n-fetch": "^1.0.0-beta.4",
+    "isomorphic-fetch": "^2.2.1",
     "request": "^2.83.0",
     "winston": "^2.4.0"
   },
@@ -24,7 +24,7 @@
     "chai": "^4.1.2",
     "chai-string": "^1.4.0",
     "mocha": "^4.1.0",
-    "nock": "^9.1.6",
+    "nock": "^9.0.2",
     "proxyquire": "^1.8.0",
     "sinon": "^4.1.3",
     "sinon-chai": "^2.14.0"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "prepush": "make verify -j3"
   },
   "dependencies": {
+    "@financial-times/n-fetch": "^1.0.0-beta.4",
     "request": "^2.83.0",
     "winston": "^2.4.0"
   },
@@ -23,6 +24,8 @@
     "chai": "^4.1.2",
     "chai-string": "^1.4.0",
     "mocha": "^4.1.0",
+    "nock": "^9.1.6",
+    "proxyquire": "^1.8.0",
     "sinon": "^4.1.3",
     "sinon-chai": "^2.14.0"
   },

--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -1,0 +1,10 @@
+module.exports = {
+	files: {
+		allow: [],
+		allowOverrides: []
+	},
+	strings: {
+		deny: [],
+		denyOverrides: []
+	}
+};

--- a/src/lib/app-logger.js
+++ b/src/lib/app-logger.js
@@ -2,12 +2,13 @@ import winston from 'winston';
 
 import Logger from './logger';
 import Splunk from './transports/splunk';
+import SplunkHEC from './transports/splunkHEC';
 
 class AppLogger extends Logger {
 
 	constructor (deps = {}) {
 		super(deps);
-		Object.assign(this.deps, { winston, Splunk }, deps);
+		Object.assign(this.deps, { winston, Splunk, SplunkHEC }, deps);
 		this.logger = new (this.deps.winston.Logger)({
 					transports: [
 						new (this.deps.winston.transports.Console)({
@@ -58,6 +59,23 @@ class AppLogger extends Logger {
 			return;
 		}
 		this.logger.remove('splunk');
+	}
+
+	addSplunkHEC (level = 'info', opts = {}) {
+		if (this.logger.transports.splunkHEC) {
+			return;
+		}
+		this.logger.add(
+			this.deps.SplunkHEC,
+			Object.assign({ level }, opts)
+		);
+	}
+
+	removeSplunkHEC () {
+		if (!this.logger.transports.splunkHEC) {
+			return;
+		}
+		this.logger.remove('SplunkHEC');
 	}
 
 	clearLoggers () {

--- a/src/lib/app-logger.js
+++ b/src/lib/app-logger.js
@@ -75,7 +75,7 @@ class AppLogger extends Logger {
 		if (!this.logger.transports.splunkHEC) {
 			return;
 		}
-		this.logger.remove('SplunkHEC');
+		this.logger.remove('splunkHEC');
 	}
 
 	clearLoggers () {

--- a/src/lib/transports/splunkHEC.js
+++ b/src/lib/transports/splunkHEC.js
@@ -1,0 +1,23 @@
+import winston from 'winston';
+
+const https = require('https');
+
+class SplunkHEC extends winston.Transport {
+
+	log (level, message, meta) {
+		const httpsAgent = new https.Agent({ keepAlive: true });
+
+		return fetch('https://http-inputs-financialtimes.splunkcloud.com:443/services/collector/event', {
+			method : 'POST',
+			headers: {
+				'Authorization': `Splunk ${process.env.SPLUNK_HEC_TOKEN}`
+			},
+			followRedirect : true,
+			strictSSL: false,
+			pool : httpsAgent,
+			body : message
+		}).catch(() => {});
+	};
+
+}
+export default SplunkHEC;

--- a/src/lib/transports/splunkHEC.js
+++ b/src/lib/transports/splunkHEC.js
@@ -1,13 +1,25 @@
 import winston from 'winston';
+import formatter from '../formatter';
 
 const https = require('https');
+const fetch = require('@financial-times/n-fetch');
 
 class SplunkHEC extends winston.Transport {
 
 	log (level, message, meta) {
+		const formattedMessage = formatter({ level, message, meta, splunkFriendly: true });
 		const httpsAgent = new https.Agent({ keepAlive: true });
 
-		return fetch('https://http-inputs-financialtimes.splunkcloud.com:443/services/collector/event', {
+		const data = {
+			'time': Date.now(),
+			'host': 'localhost',
+			'source': `/var/log/apps/heroku/${process.env.SYSTEM_CODE}.log`,
+			'sourcetype': 'heroku:drain',
+			'index': 'heroku',
+			'event': { formattedMessage }
+		};
+
+		return fetch('https://http-inputs-financialtimes.splunkcloud.com/services/collector/event', {
 			method : 'POST',
 			headers: {
 				'Authorization': `Splunk ${process.env.SPLUNK_HEC_TOKEN}`
@@ -15,9 +27,10 @@ class SplunkHEC extends winston.Transport {
 			followRedirect : true,
 			strictSSL: false,
 			pool : httpsAgent,
-			body : message
+			body : JSON.stringify(data)
 		}).catch(() => {});
 	};
 
 }
+
 export default SplunkHEC;

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,10 @@ const getLogger = () => {
 			level: process.env.CONSOLE_LOG_LEVEL || 'silly'
 		});
 
+		if (process.env.NODE_ENV === 'production' && process.env.SPLUNK_HEC_TOKEN) {
+			logger.addSplunkHEC(process.env.SPLUNK_LOG_LEVEL || 'warn');
+		}
+
 		// log to splunk only in production
 		if (process.env.NODE_ENV === 'production' && process.env.SPLUNK_URL) {
 			logger.addSplunk(process.env.SPLUNK_URL, process.env.SPLUNK_LOG_LEVEL || 'warn');

--- a/test/lib/app-logger.test.js
+++ b/test/lib/app-logger.test.js
@@ -243,6 +243,57 @@ describe('Logger', () => {
 
 	});
 
+	describe('#addSplunkHEC', () => {
+
+		it('should be able to add a splunkHEC logger', () => {
+			const addSpy = sinon.spy();
+			const SplunkHECSpy = sinon.spy();
+			const winston = winstonStub({ add: addSpy });
+			const logger = new Logger({ winston, SplunkHEC: SplunkHECSpy });
+			logger.addSplunkHEC();
+			addSpy.should.always.have.been.calledWithExactly(SplunkHECSpy, { level: 'info' });
+		});
+
+		it('should be able to set the console logger\'s level', () => {
+			const addSpy = sinon.spy();
+			const SplunkHECSpy = sinon.spy();
+			const winston = winstonStub({ add: addSpy });
+			const logger = new Logger({ winston, SplunkHEC: SplunkHECSpy });
+			logger.addSplunkHEC('warn');
+			addSpy.should.always.have.been.calledWithExactly(SplunkHECSpy, { level: 'warn' });
+		});
+
+		it('should not be able to add if already added', () => {
+			const addSpy = sinon.spy(function () { this.transports.splunkHEC = true; });
+			const winston = winstonStub({ add: addSpy });
+			const logger = new Logger({ winston });
+			logger.addSplunkHEC();
+			logger.addSplunkHEC();
+			addSpy.should.have.been.calledOnce;
+		});
+
+	});
+
+	describe('#removeSplunkHEC', () => {
+
+		it('should be able to remove', () => {
+			const removeSpy = sinon.spy();
+			const winston = winstonStub({ remove: removeSpy, transports: { splunkHEC: true } });
+			const logger = new Logger({ winston });
+			logger.removeSplunkHEC();
+			removeSpy.should.always.have.been.calledWithExactly('splunkHEC');
+		});
+
+		it('should not be able to remove if not added', () => {
+			const removeSpy = sinon.spy();
+			const winston = winstonStub({ remove: removeSpy });
+			const logger = new Logger({ winston });
+			logger.removeSplunkHEC();
+			removeSpy.should.not.have.been.called;
+		});
+
+	});
+
 	describe('#clearLoggers', () => {
 
 		it('should be able to clear loggers', () => {

--- a/test/lib/transports/splunkHEC.test.js
+++ b/test/lib/transports/splunkHEC.test.js
@@ -1,6 +1,8 @@
 const chai = require('chai');
 chai.should();
 
+require('isomorphic-fetch');
+
 const nock = require('nock');
 const proxyquire = require('proxyquire');
 
@@ -36,12 +38,13 @@ describe('SplunkHEC', () => {
 
 			const splunkHECTransport = new SplunkHEC();
 			return splunkHECTransport.log('error', 'a message', { field: 'value' })
-				.then(res => {
-					res.text.should.equal('Successful request');
+				.then(res => res.json())
+				.then(json => {
+					json.text.should.equal('Successful request');
 				});
 		});
 
-		it('should not throw exceptions', () => {
+		it('should not throw exceptions when Splunk is down', () => {
 			nock('https://http-inputs-financialtimes.splunkcloud.com')
 				.post('/services/collector/event')
 				.reply(500);
@@ -49,11 +52,8 @@ describe('SplunkHEC', () => {
 			const splunkHECTransport = new SplunkHEC();
 			return splunkHECTransport.log('error', 'a message', { field: 'value' });
 		});
-	});
 
-	describe('when Splunk is not accepting requests', () => {
-
-		it('should not throw exceptions', () => {
+		it('should not throw exceptions when Splunk does not accept the request', () => {
 			nock('https://http-inputs-financialtimes.splunkcloud.com')
 				.post('/services/collector/event')
 				.reply(400);

--- a/test/lib/transports/splunkHEC.test.js
+++ b/test/lib/transports/splunkHEC.test.js
@@ -1,8 +1,16 @@
-import sinon from 'sinon';
-import chai from 'chai';
+const chai = require('chai');
 chai.should();
 
-import SplunkHEC from '../../../dist/lib/transports/splunkHEC';
+const nock = require('nock');
+const proxyquire = require('proxyquire');
+
+const formatter = () => {
+	return 'a message field=value level=error';
+};
+
+const SplunkHEC = proxyquire('../../../dist/lib/transports/splunkHEC', {
+	'../formatter': formatter
+}).default;
 
 describe('SplunkHEC', () => {
 
@@ -16,10 +24,42 @@ describe('SplunkHEC', () => {
 	});
 
 	describe('log', () => {
-		it('should send a message to Splunk', () => {
-			const splunkHECTransport = new SplunkHEC();
 
+		afterEach(() => {
+			nock.cleanAll();
+		});
+
+		it('should return an object', () => {
+			nock('https://http-inputs-financialtimes.splunkcloud.com')
+				.post('/services/collector/event')
+				.reply(201, { text: 'Successful request', code: 0 });
+
+			const splunkHECTransport = new SplunkHEC();
+			return splunkHECTransport.log('error', 'a message', { field: 'value' })
+				.then(res => {
+					res.text.should.equal('Successful request');
+				});
+		});
+
+		it('should not throw exceptions', () => {
+			nock('https://http-inputs-financialtimes.splunkcloud.com')
+				.post('/services/collector/event')
+				.reply(500);
+
+			const splunkHECTransport = new SplunkHEC();
 			return splunkHECTransport.log('error', 'a message', { field: 'value' });
+		});
+	});
+
+	describe('when Splunk is not accepting requests', () => {
+
+		it('should not throw exceptions', () => {
+			nock('https://http-inputs-financialtimes.splunkcloud.com')
+				.post('/services/collector/event')
+				.reply(400);
+
+			const splunkHECTransport = new SplunkHEC();
+			return splunkHECTransport.log('info', 'a message', { field: 'value' });
 		});
 	});
 

--- a/test/lib/transports/splunkHEC.test.js
+++ b/test/lib/transports/splunkHEC.test.js
@@ -31,7 +31,7 @@ describe('SplunkHEC', () => {
 			nock.cleanAll();
 		});
 
-		it('should return an object', () => {
+		it('should send a log to Splunk', () => {
 			nock('https://http-inputs-financialtimes.splunkcloud.com')
 				.post('/services/collector/event')
 				.reply(201, { text: 'Successful request', code: 0 });

--- a/test/lib/transports/splunkHEC.test.js
+++ b/test/lib/transports/splunkHEC.test.js
@@ -1,0 +1,26 @@
+import sinon from 'sinon';
+import chai from 'chai';
+chai.should();
+
+import SplunkHEC from '../../../dist/lib/transports/splunkHEC';
+
+describe('SplunkHEC', () => {
+
+	it('should exist', () => {
+		SplunkHEC.should.exist;
+	});
+
+	it('should be able to instantiate', () => {
+		const splunkHECTransport = new SplunkHEC();
+		splunkHECTransport.should.exist;
+	});
+
+	describe('log', () => {
+		it('should send a message to Splunk', () => {
+			const splunkHECTransport = new SplunkHEC();
+
+			return splunkHECTransport.log('error', 'a message', { field: 'value' });
+		});
+	});
+
+});


### PR DESCRIPTION
See issue #55 

Splunk 6.3 introduced a new high performance data input option for developers to send event data directly to Splunk over HTTP(s) called the HTTP Event Collector (HEC). This eliminates the need for a forwarder and should be faster and more efficient. 

The Splunk HEC transport is added If `NODE_ENV === production` and `SPLUNK_HEC_TOKEN` is present. This HEC token is stored in shared vault secrets/teams/next/shared/production.

Each request contains a HEC token within an authorization header, event metadata made up of several key-value pairs and event data which can be in any format. 

The HEC also supports sending batches of events to Splunk to further improve performance, which could be the next thing to implement once I have confirmed this is working.




