### PR TITLE
update to ignore child-process and fs on client

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,9 @@
   "config": {},
   "engines": {
     "node": ">=6.1.0"
+  },
+  "browser": {
+     "fs": false, 
+     "child_process": false 
   }
 }


### PR DESCRIPTION
When using n-logger with a client-side app webpack will fail to resolve modules which are not browser compatible and will throw an error.  This allows us to ignore these modules on the client side.