### PR TITLE
Added SPLUNK_INDEX env variable

### DIFF
--- a/src/lib/transports/splunkHEC.js
+++ b/src/lib/transports/splunkHEC.js
@@ -13,7 +13,7 @@ class SplunkHEC extends winston.Transport {
 			'host': 'localhost',
 			'source': `/var/log/apps/heroku/ft-${process.env.SYSTEM_CODE}.log`,
 			'sourcetype': '_json',
-			'index': 'heroku',
+			'index': process.env.SPLUNK_INDEX || 'heroku',
 			'event': formattedMessage
 		};
 


### PR DESCRIPTION
 🐿 v2.8.0

Used an environment variable SPLUNK_INDEX to pass on a custom index as opposed to using a predefined 'heroku' index