### PR TITLE
add optional deploymentStage splunk log date

### DIFF
--- a/src/lib/transports/splunkHEC.js
+++ b/src/lib/transports/splunkHEC.js
@@ -13,6 +13,7 @@ class SplunkHEC extends winston.Transport {
 			'host': 'localhost',
 			'source': `/var/log/apps/heroku/ft-${process.env.SYSTEM_CODE}.log`,
 			'sourcetype': '_json',
+			'deploymentStage': process.env.DEPLOYMENT_STAGE || 'production',
 			'index': process.env.SPLUNK_INDEX || 'heroku',
 			'event': formattedMessage
 		};


### PR DESCRIPTION
This addds an optional `deploymentStage` property to Splunk logs, the reason we'd like this is that we have a staging environment which we would like to log but would want to be easily differentiated from the production service. 

Adding this would make it easier to filter staging from production logs for example:
<img width="620" alt="screenshot 2018-07-04 16 08 26" src="https://user-images.githubusercontent.com/11544418/42284495-97d80ea0-7fa4-11e8-9a69-73abe018517b.png">
