### PR TITLE
Add a timeout to splunk HEC call

### DIFF
--- a/src/lib/transports/splunkHEC.js
+++ b/src/lib/transports/splunkHEC.js
@@ -23,6 +23,7 @@ class SplunkHEC extends winston.Transport {
 				'Authorization': `Splunk ${process.env.SPLUNK_HEC_TOKEN}`
 			},
 			pool: httpsAgent,
+			timeout: 3000,
 			body: JSON.stringify(data)
 		}).catch(() => {});
 	};


### PR DESCRIPTION
I'm not sure this is a root cause or not - but probably isn't helping. The response times to splunk take up to 40s, and that probably has a knock on effect on other requests.

This _may_ lead to some dropped errors, but probably acceptable?