### PR TITLE
Use `util.inspect` instead of `JSON.stringify` for logging

### DIFF
--- a/src/lib/transports/splunkHEC.js
+++ b/src/lib/transports/splunkHEC.js
@@ -1,4 +1,5 @@
 import winston from 'winston';
+import { inspect } from 'util';
 import formatHEC from '../formatHEC';
 const https = require('https');
 
@@ -24,7 +25,7 @@ class SplunkHEC extends winston.Transport {
 			},
 			pool: httpsAgent,
 			timeout: 3000,
-			body: JSON.stringify(data)
+			body: inspect(data)
 		}).catch(() => {});
 	};
 

--- a/test/lib/transports/splunkHEC.test.js
+++ b/test/lib/transports/splunkHEC.test.js
@@ -61,6 +61,17 @@ describe('SplunkHEC', () => {
 			const splunkHECTransport = new SplunkHEC();
 			return splunkHECTransport.log('info', 'a message', { field: 'value' });
 		});
+
+		it('should send a log if data is circularly referenced', () => {
+			nock('https://http-inputs-financialtimes.splunkcloud.com')
+				.post('/services/collector/event')
+				.reply(201, { text: 'Successful request', code: 0 });
+
+			const splunkHECTransport = new SplunkHEC();
+			const circularData = { field: 'value' };
+			circularData.circularData = circularData;
+			return splunkHECTransport.log('info', 'a message', circularData);
+		});
 	});
 
 });


### PR DESCRIPTION
To allow for circular data 🐿 v2.10.3

Fixes https://github.com/Financial-Times/n-logger/issues/79