### PR TITLE
Fix SplunkHEC not logging because of non-JSON body

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "isomorphic-fetch": "^2.2.1",
+    "json-stringify-safe": "^5.0.1",
     "request": "^2.83.0",
     "winston": "^2.4.0"
   },

--- a/src/lib/transports/splunkHEC.js
+++ b/src/lib/transports/splunkHEC.js
@@ -1,6 +1,7 @@
 import winston from 'winston';
-import { inspect } from 'util';
+import stringify from 'json-stringify-safe';
 import formatHEC from '../formatHEC';
+
 const https = require('https');
 
 class SplunkHEC extends winston.Transport {
@@ -25,7 +26,7 @@ class SplunkHEC extends winston.Transport {
 			},
 			pool: httpsAgent,
 			timeout: 3000,
-			body: inspect(data)
+			body: stringify(data)
 		}).catch(() => {});
 	};
 

--- a/src/lib/transports/splunkHEC.js
+++ b/src/lib/transports/splunkHEC.js
@@ -4,6 +4,18 @@ import formatHEC from '../formatHEC';
 
 const https = require('https');
 
+const throwIfNotOk = res => {
+	const { ok, status, url } = res;
+	if (!ok) {
+		return res.json()
+			.then(errorBody => {
+				console.error('Fetch error:', status, url, errorBody); // eslint-disable-line no-console
+				throw errorBody;
+			});
+	}
+	return res;
+};
+
 class SplunkHEC extends winston.Transport {
 
 	log (level, message, meta) {
@@ -27,7 +39,12 @@ class SplunkHEC extends winston.Transport {
 			pool: httpsAgent,
 			timeout: 3000,
 			body: stringify(data)
-		}).catch(() => {});
+		})
+			.then(throwIfNotOk)
+			.catch((error) => {
+				/* eslint no-console: 0 */
+				console.log('Error logging to splunk', error, data);
+			});
 	};
 
 }


### PR DESCRIPTION
Due to this https://github.com/Financial-Times/n-logger/pull/80, splunk requests fail on every log. This is because splunk expects the logs to be in a JSON format, which `util.inspect` does not do (doesn't include quotes in keys).

See https://repl.it/@taktran/Difference-between-utilinspect-and-jsonstringify for a more thorough analysis of the differences between `util.inspect` and `JSON.stringify`.

I've opted to use [json-stringify-safe](https://www.npmjs.com/package/json-stringify-safe) to fix both https://github.com/Financial-Times/n-logger/issues/79 and having JSON.parse-able content. It seems the most reputable of the alternatives and prints out circular dependencies in a neat way eg, `[Circular ~.event.data]`.