### PR TITLE
Expose logger factory 🏭

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,24 @@ If using CommonJS modules
 
     const logger = require('@financial-times/n-logger').default;
 
+You may also have different instances of the logger in the same project.  This is useful if you wanted to have different [context](#addcontextmeta) per logger:
+
+```javascript
+  const logger = require('@financial-times/n-logger');
+
+  const logger1 = logger.getLogger();
+  logger1.addContext({ client: 'api-service-1' });
+
+  const logger2 = logger.getLogger();
+  logger2.addContext({ client: 'api-service-2' });
+
+  logger1.info('message 1');
+  logger2.info('message 1');
+
+  // this outputs the following (note the client is different)
+  // info: message 1 client=api-service-1
+  // info: message 1 client=api-service-2
+```
 ### Loggers
 
 By default, the following loggers are added:

--- a/src/main.js
+++ b/src/main.js
@@ -23,3 +23,4 @@ const getLogger = () => {
 
 const logger = getLogger();
 export default logger;
+export { getLogger };


### PR DESCRIPTION
Allows self-contained use of the addContext method per component.

Use-case: If you have an analytics component in your app, you might want
to use the [logger.addContext](https://github.com/financial-times/n-logger#addcontextmeta) method to attribute `logSource: 'analytics'` to all logs that come from that component. This is much easier to achieve if each component can have their own instance of the logger ✌️.

 🐿 v2.11.0