### PR TITLE
Allow overriding Splunk fields in log entries

### DIFF
--- a/src/lib/transports/splunkHEC.js
+++ b/src/lib/transports/splunkHEC.js
@@ -25,7 +25,7 @@ class SplunkHEC extends winston.Transport {
 
 		const data = {
 			'time': Date.now(),
-			'host': 'localhost',
+			'host': process.env.N_LOGGER_HOSTNAME || 'localhost',
 			'source': `/var/log/apps/${hostPlatform}/ft-${process.env.SYSTEM_CODE}.log`,
 			'sourcetype': process.env.SPLUNK_SOURCETYPE || '_json',
 			'index': process.env.SPLUNK_INDEX || 'heroku',

--- a/src/lib/transports/splunkHEC.js
+++ b/src/lib/transports/splunkHEC.js
@@ -21,11 +21,12 @@ class SplunkHEC extends winston.Transport {
 	log (level, message, meta) {
 		const httpsAgent = new https.Agent({ keepAlive: true });
 		const formattedMessage = formatHEC({ level, message, meta });
+		const hostPlatform = process.env.HOST_PLATFORM || 'heroku';
 
 		const data = {
 			'time': Date.now(),
 			'host': 'localhost',
-			'source': `/var/log/apps/heroku/ft-${process.env.SYSTEM_CODE}.log`,
+			'source': `/var/log/apps/${hostPlatform}/ft-${process.env.SYSTEM_CODE}.log`,
 			'sourcetype': process.env.SPLUNK_SOURCETYPE || '_json',
 			'index': process.env.SPLUNK_INDEX || 'heroku',
 			'event': formattedMessage


### PR DESCRIPTION
The source field is hardcoded to include the word "heroku" but as far as I can see there's nothing in the repo that requires apps to be hosted on Heroku in order to use n-logger.

I'd like to integrate n-logger with a couple of apps that are hosted on FT Platform. These apps currently log to the filesystem and splunkd then collects the logs to send them to Splunk. Integrating n-logger will make it much easier to move these apps to Heroku in the future.

This commit will allow those apps to use n-logger while hosted on FT Platform without making the source field confusing. 🐿 v2.12.5