### PR TITLE
Remove unused dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "isomorphic-fetch": "^2.2.1",
     "json-stringify-safe": "^5.0.1",
-    "request": "^2.83.0",
     "winston": "^2.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
A search of this repo using a text editor indicates that the `request` dependency is not being used anywhere.

In addition:

https://www.npmjs.com/package/request

> **Deprecated!**
As of Feb 11th 2020, request is fully deprecated. No new changes are expected land. In fact, none have landed for some time.