### PR TITLE
CPP-555 expose a setSystemCode, and deprecate SYSTEM_CODE

### DIFF
--- a/src/lib/app-logger.js
+++ b/src/lib/app-logger.js
@@ -61,6 +61,11 @@ class AppLogger extends Logger {
 			.forEach(logger => this.logger.remove(logger));
 	}
 
+	setSystemCode(systemCode) {
+		if(this.logger.transports.splunkHEC) {
+			this.logger.transports.splunkHEC.setSystemCode(systemCode)
+		}
+	}
 }
 
 export default AppLogger;

--- a/src/lib/app-logger.js
+++ b/src/lib/app-logger.js
@@ -61,9 +61,9 @@ class AppLogger extends Logger {
 			.forEach(logger => this.logger.remove(logger));
 	}
 
-	setSystemCode(systemCode) {
+	setSystemCode (systemCode) {
 		if(this.logger.transports.splunkHEC) {
-			this.logger.transports.splunkHEC.setSystemCode(systemCode)
+			this.logger.transports.splunkHEC.setSystemCode(systemCode);
 		}
 	}
 }

--- a/src/lib/transports/splunkHEC.js
+++ b/src/lib/transports/splunkHEC.js
@@ -18,6 +18,30 @@ const throwIfNotOk = res => {
 };
 
 class SplunkHEC extends winston.Transport {
+	// name that Winston refers to the transport by
+	get name() {
+		return 'splunkHEC';
+	}
+
+	setSystemCode(systemCode) {
+		this._systemCode = systemCode;
+	}
+
+	get systemCode() {
+		if(this._systemCode) {
+			return this._systemCode;
+		} else if(process.env.SYSTEM_CODE) {
+			// fall back to legacy environment variable with a warning
+			if(!this.warnedSystemCode) {
+				console.warn('n-logger Splunk transport received the system code from the SYSTEM_CODE environment variable, which is deprecated. Call logger.setSystemCode instead');
+				this.warnedSystemCode = true;
+			}
+
+			return process.env.SYSTEM_CODE;
+		} else {
+			throw new Error('You must set the systemCode option to a valid Biz Ops system code (call logger.setSystemCode) to use the Splunk transport.');
+		}
+	}
 
 	log (level, message, meta) {
 		const httpsAgent = new https.Agent({ keepAlive: true });
@@ -26,7 +50,7 @@ class SplunkHEC extends winston.Transport {
 		const data = {
 			'time': Date.now(),
 			'host': 'localhost',
-			'source': `/var/log/apps/heroku/ft-${process.env.SYSTEM_CODE}.log`,
+			'source': `/var/log/apps/heroku/ft-${this.systemCode}.log`,
 			'sourcetype': process.env.SPLUNK_SOURCETYPE || '_json',
 			'index': process.env.SPLUNK_INDEX || 'heroku',
 			'event': formattedMessage

--- a/src/lib/transports/splunkHEC.js
+++ b/src/lib/transports/splunkHEC.js
@@ -19,15 +19,15 @@ const throwIfNotOk = res => {
 
 class SplunkHEC extends winston.Transport {
 	// name that Winston refers to the transport by
-	get name() {
+	get name () {
 		return 'splunkHEC';
 	}
 
-	setSystemCode(systemCode) {
+	setSystemCode (systemCode) {
 		this._systemCode = systemCode;
 	}
 
-	get systemCode() {
+	get systemCode () {
 		if(this._systemCode) {
 			return this._systemCode;
 		} else if(process.env.SYSTEM_CODE) {

--- a/test/lib/transports/splunkHEC.test.js
+++ b/test/lib/transports/splunkHEC.test.js
@@ -13,6 +13,9 @@ const SplunkHEC = proxyquire('../../../dist/lib/transports/splunkHEC', {
 	'../formatter': formatter
 }).default;
 
+// required for Splunk URL
+process.env.SYSTEM_CODE = 'n-logger';
+
 describe('SplunkHEC', () => {
 
 	it('should exist', () => {


### PR DESCRIPTION
n-logger's Splunk transport currently depends on a SYSTEM_CODE being set, which is done by n-heroku-tools when it configures an app. this creates unnecessary coupling between our deployment process and our logger.

n-express already has a mandatory system code option, and everything using n-heroku-tools and n-logger is also using n-express, so instead let's expose a function that n-express can call to set the system code here.