### PR TITLE
Allow apps to use Heroku log drains

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,17 @@ const logger = require('@financial-times/n-logger').default;
 
 ### Loggers
 
-By default, the following loggers are configured:
+The default loggers are configured based on the presence of several environment variables. A `Console` logger is always registered and a `SplunkHEC` logger is registered depending on which variables are set:
 
-  1. **The `console` logger**
+  - **`MIGRATE_TO_HEROKU_LOG_DRAINS`:** Whether the app should rely on Heroku log drains in production. If this variable is set to an unempty string then the app will _not_ log directly to Splunk. Instead it will log JSON strings to the console which should be picked up by Heroku and forwarded on to Splunk. **Do not set this environment variable before configuring a Heroku log drain in your application**.
 
-      The default logger. The log levels to output to the terminal can be set using the `CONSOLE_LOG_LEVEL` environment variable (defaults to `silly`). The log coloring can be disabled by setting `CONSOLE_LOG_UNCOLORIZED` environment variable to `true` by default the colorizing is enabled.
+  - **`SPLUNK_HEC_TOKEN`:** The Splunk token to use when manually sending logs to Splunk. If this is set to an unempty string then a SplunkHEC logger will be configured.
 
-  2. **The `splunkHEC` logger**
+  - **`SPLUNK_LOG_LEVEL`:** The log levels to send to Splunk, used by both Heroku log drains and the SplunkHEC logger. Defaults to `warn`.
 
-      Used if the `SPLUNK_HEC_TOKEN` environment variable is present. The log levels to send to Splunk can be set using the `SPLUNK_LOG_LEVEL` environment variable (defaults to `warn`).
+  - **`CONSOLE_LOG_LEVEL`:** The log levels to send to the console. Defaults to `silly`. This environment variable is ignored in favour of `SPLUNK_LOG_LEVEL` when `MIGRATE_TO_HEROKU_LOG_DRAINS` is in use.
+
+  - **`CONSOLE_LOG_UNCOLORIZED`:** Set to `true` to disable log coloring. By default console logs are colorized. This environment variable is ignored when `MIGRATE_TO_HEROKU_LOG_DRAINS` is in use as JSON logs are not colorized.
 
 
 ## Testing n-logger locally

--- a/src/lib/app-logger.js
+++ b/src/lib/app-logger.js
@@ -12,7 +12,9 @@ class AppLogger extends Logger {
 			transports: [
 				new (this.deps.winston.transports.Console)({
 					colorize: deps.colorize,
-					level: deps.level
+					level: deps.level,
+					json: this.deps.json,
+					stringify: true // This ensures that any JSON logs are single-line
 				})
 			]
 		});

--- a/src/lib/app-logger.js
+++ b/src/lib/app-logger.js
@@ -11,8 +11,8 @@ class AppLogger extends Logger {
 		this.logger = new (this.deps.winston.Logger)({
 			transports: [
 				new (this.deps.winston.transports.Console)({
-					colorize: deps.colorize,
-					level: deps.level,
+					colorize: this.deps.colorize,
+					level: this.deps.level,
 					json: this.deps.json,
 					stringify: true // This ensures that any JSON logs are single-line
 				})

--- a/src/main.js
+++ b/src/main.js
@@ -9,19 +9,15 @@ const getLogger = () => {
 		// app environment - use Winston
 
 		// Determine whether the app is using Heroku log drains or Splunk HEC
-		const useHerokuLogDrains = process.env.MIGRATE_TO_HEROKU_LOG_DRAINS;
+		const useHerokuLogDrains = Boolean(process.env.MIGRATE_TO_HEROKU_LOG_DRAINS);
 		const splunkToken = process.env.SPLUNK_HEC_TOKEN;
 
 		// Determine the log level
-		let logLevel = 'silly';
-		if (useHerokuLogDrains) {
-			logLevel = process.env.SPLUNK_LOG_LEVEL || 'warn';
-		} else {
-			logLevel = process.env.CONSOLE_LOG_LEVEL || 'silly';
-		}
+		const splunkLogLevel = process.env.SPLUNK_LOG_LEVEL || 'warn';
+		const consoleLogLevel = process.env.CONSOLE_LOG_LEVEL || 'silly';
 
 		const logger = new AppLogger({
-			level: logLevel,
+			level: (useHerokuLogDrains ? splunkLogLevel : consoleLogLevel),
 			colorize: process.env.CONSOLE_LOG_UNCOLORIZED !== 'true',
 
 			// If we're migrating to Heroku log drains then we want
@@ -32,7 +28,7 @@ const getLogger = () => {
 		// If we have a Splunk token and we're not using log drains,
 		// then add a Splunk HEC transport to the logger
 		if (splunkToken && !useHerokuLogDrains) {
-			logger.addSplunkHEC(process.env.SPLUNK_LOG_LEVEL || 'warn');
+			logger.addSplunkHEC(splunkLogLevel);
 		}
 
 		return logger;

--- a/src/main.js
+++ b/src/main.js
@@ -8,11 +8,9 @@ const getLogger = () => {
 	} else {
 		// app environment - use Winston
 
-		// Determine whether the app is using Heroku log drains
-		const useHerokuLogDrains = (
-			process.env.MIGRATE_TO_HEROKU_LOG_DRAINS &&
-			process.env.MIGRATE_TO_HEROKU_LOG_DRAINS.length > 0
-		);
+		// Determine whether the app is using Heroku log drains or Splunk HEC
+		const useHerokuLogDrains = process.env.MIGRATE_TO_HEROKU_LOG_DRAINS;
+		const splunkToken = process.env.SPLUNK_HEC_TOKEN;
 
 		// Determine the log level
 		let logLevel = 'silly';
@@ -33,7 +31,7 @@ const getLogger = () => {
 
 		// If we have a Splunk token and we're not using log drains,
 		// then add a Splunk HEC transport to the logger
-		if (!useHerokuLogDrains && process.env.SPLUNK_HEC_TOKEN && process.env.SPLUNK_HEC_TOKEN.length > 0) {
+		if (splunkToken && !useHerokuLogDrains) {
 			logger.addSplunkHEC(process.env.SPLUNK_LOG_LEVEL || 'warn');
 		}
 


### PR DESCRIPTION
This introduces a new environment variable:
`MIGRATE_TO_HEROKU_LOG_DRAINS`.

This variable can be set to switch off the Splunk HEC logging and output
JSON logs instead of key/value pairs. This means that an app can utilize
[Heroku log drains](https://tech.in.ft.com/tech-topics/logging/splunk/logging-from-heroku) which gives us a lot more useful information.

This has been tested using [a new Heroku app](https://dashboard.heroku.com/apps/ft-dotcom-testing-log-drains) which uses the version
of n-logger on this branch:

* **[Test app using the Splunk HEC logger](https://financialtimes.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dheroku%20source%3D%22%2Fvar%2Flog%2Fapps%2Fheroku%2Fft-ft-dotcom-testing-log-drains.log%22&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=1657098480&latest=1657102108)**

    `SPLUNK_HEC_TOKEN` set to a valid token,
    `MIGRATE_TO_HEROKU_LOG_DRAINS` not set,
    sends the following logs to Splunk:

    ```json
    {"level":"info","message":"Application Started","port":"XXXXX"}
    {"level":"info","message":"Hello"}
    ```

* **[Test app using the log drain](https://financialtimes.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dheroku%20source%3Dft-dotcom-testing-log-drains%20sourcetype%3Dheroku&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=1657102080&latest=1657102200)**

    `SPLUNK_HEC_TOKEN` not set,
    `MIGRATE_TO_HEROKU_LOG_DRAINS` set to `true`,
    sends the following logs to Splunk:

    ```json
    {"level":"info","message":"Application Started","port":"XXXXX"}
    {"level":"info","message":"Hello"}
    ```